### PR TITLE
Change module name from 'lofitui' to 'willyv3/lofitui'

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lofitui
+module github.com/willyv3/lofitui
 
 go 1.25.4
 


### PR DESCRIPTION
This was causing an issue with 'go install github.com/lofitui@latest' command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module configuration to reflect repository changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->